### PR TITLE
Add fading text on keypress

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -6,6 +6,20 @@ img {
     -webkit-user-select: none;
     -ms-user-select: none;
 }
+html,
 body {
-    text-align: center;
+  width: 100%;
+  height: 100%;
+  margin: 0px;
+  border: 0;
+  text-align: center;
+  overflow: hidden;
+  /*  Disable scrollbars */
+  display: block;
+  /* No floating content on sides */
 }
+.canvas { position: absolute; top: 0; left: 0; }
+
+#container canvas, #overlay {
+    position: absolute;
+  }

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1,9 +1,162 @@
-function setRandomColor() {
+function getRandomRgb() {
+    var num = Math.round(0xffffff * Math.random());
+    var r = num >> 16;
+    var g = num >> 8 & 255;
+    var b = num & 255;
+    return 'rgb(' + r + ', ' + g + ', ' + b + ')';
+}
+
+function getRandomHexColor() {
     return "#" + ("00000" + Math.floor(Math.random() * Math.pow(16, 6)).toString(16)).slice(-6);
 }
+
+class RandomRGB {
+    constructor() {
+        var num = Math.round(0xffffff * Math.random());
+        this.r = num >> 16;
+        this.g = num >> 8 & 255;
+        this.b = num & 255;
+    }
+
+    toRgba(alpha) {
+        return 'rgba(' + this.r + ', ' + this.g + ', ' + this.b + ', ' + alpha + ')';
+    }
+}
+
+class TextItem {
+    constructor(x, y, text, rgb) {
+        this.x = x;
+        this.y = y;
+        this.text = text;
+        this.rgb = rgb;
+        this.alpha = 1;
+    }
+
+    fade(val) {
+        this.alpha = this.alpha - val;
+    }
+
+    draw(canvas) {
+        var ctx = canvas.getContext('2d');
+        ctx.font = '48px serif';
+        ctx.fillStyle = this.rgb.toRgba(this.alpha);
+        ctx.fillText(this.text, this.x, this.y);
+    }
+}
+
+const Application = new class {
+    constructor() {
+        // Some configuration options
+
+        // The number of characters we can display on the screen at a time
+        this.max_num_elements = 300;
+        // The intensity at which text should fade out per re-evaluation
+        this.alpha_fade_per_interval = .010;
+        // How often we should re-evaluate the alpha level for each text item
+        this.fade_out_refresh_interval_milliseconds = 50;
+        // How many random text items we should generate per key press
+        this.text_multiplier = 3;
+
+        // Tracking of items to draw
+        this.elements = [];
+    }
+
+    /**
+     * Handle the key press of user. Displayable keys are added to a list of text to draw, non displayable results
+     * in a refresh of the current background colour
+     * 
+     * @param {The key that was pressed by the user} key 
+     */
+    handleKeyPress(key) {
+        let color = getRandomHexColor();
+        if (key.match(/^[0-9A-Za-z]+$/) === null) {
+            document.body.style.backgroundColor = color;
+        }
+        else {
+            const canvas = document.getElementById('maincanvas');
+
+            for(var i = 0; i < Application.text_multiplier; i++) {
+                var x = Math.floor(Math.random() * (canvas.width));
+                var y = Math.floor(Math.random() * (canvas.height));
+
+                Application.elements.push(new TextItem(x, y, key, new RandomRGB()));
+            }
+
+            if (Application.elements.length > Application.max_num_elements)
+                Application.elements.shift();
+        }
+    }
+
+    /**
+     * Refresh all drawable elements with their adjusted alpha fade
+     */
+    redraw() {
+        const canvas = document.getElementById('maincanvas');
+        // Clear the canvas
+        canvas.width = canvas.width;
+
+
+        for (var i = Application.elements.length - 1; i >= 0; i--) {
+            var element = Application.elements[i];
+            element.draw(canvas);
+
+            element.fade(Application.alpha_fade_per_interval);
+            if (element.alpha <= 0)
+                Application.elements.splice(i, 1);
+        }
+    }
+
+    /**
+     * Spawn a periodic loop to fade displayed text
+     */
+    runLoop() {
+        setInterval(this.redraw, this.fade_out_refresh_interval_milliseconds);
+    }
+
+}
+
 window.addEventListener('click', event => {
-    document.body.style.backgroundColor = setRandomColor();
+    document.body.style.backgroundColor = getRandomHexColor();
 });
-window.addEventListener('keypress', event => {
-    document.body.style.backgroundColor = setRandomColor();
+window.addEventListener('keydown', function (e) {
+    Application.handleKeyPress(e.key)
 });
+
+// Fill the full window with the canvas
+(function () {
+    var
+        // Obtain a reference to the canvas element using its id.
+        htmlCanvas = document.getElementById('maincanvas'),
+        // Obtain a graphics context on the canvas element for drawing.
+        context = htmlCanvas.getContext('2d');
+
+    // Start listening to resize events and draw canvas.
+    initialize();
+
+    function initialize() {
+        // Register an event listener to call the resizeCanvas() function 
+        // each time the window is resized.
+        window.addEventListener('resize', resizeCanvas, false);
+        // Draw canvas border for the first time.
+        resizeCanvas();
+    }
+
+    // Display custom canvas. In this case it's a blue, 5 pixel 
+    // border that resizes along with the browser window.
+    function redraw() {
+        context.strokeStyle = 'blue';
+        context.lineWidth = '5';
+        context.strokeRect(0, 0, window.innerWidth, window.innerHeight);
+    }
+
+    // Runs each time the DOM window resize event fires.
+    // Resets the canvas dimensions to match window,
+    // then draws the new borders accordingly.
+    function resizeCanvas() {
+        htmlCanvas.width = window.innerWidth;
+        htmlCanvas.height = window.innerHeight;
+        redraw();
+    }
+})();
+
+Application.runLoop();

--- a/index.html
+++ b/index.html
@@ -23,15 +23,17 @@
 
     <link rel="icon" href="assets/images/logo-no-bg.png" />
     <link rel="stylesheet" href="assets/css/style.css" />
-    <script src="assets/js/script.js"></script>
 </head>
 <body>
+    <canvas id='maincanvas' style='position:absolute; left:0px; top:0px;'></canvas>
+    <div>
     <h1>Press any key or click!</h1>
     <img src="assets/images/logo-no-bg.png" alt="" />
-
+    </div>
     <!-- Google Tag Manager (noscript) -->
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5PC3XBD"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
 </body>
 </html>
+<script src="assets/js/script.js"></script>


### PR DESCRIPTION
I saw this project. Looked neat. 

My child enjoys whipping out my old sun microsystems keyboard that's hooked up to my Minecraft server terminal and pounding on it saying she has to work just like daddy. Thanks to your idea, I can leave something on rather than unplug the keyboard and it also doubles for keeping kiddos attention longer 

Threw this together tonight while enjoying the warm summer night weather waiting for the impending storm to rain on my parade. I pieced together some things from stackoverflow + some original content. I do not know how that works with license and credits. 

I think this now requires HTML5 due to the canvas, I am not a Javascript expert. Everyone should be on HTML5 now... right?

**Summary of changes:**

-  Added a Canvas to the background of the page that should fill the whole screen.
-  Keypress's result in letters or numbers popping on screen if the "Key" from the keypress args is render-able. 
-  Some parameters to control drawing, all hard coded. Ability to control redraw interval, aggressiveness of fading the alpha channel, maximum number of items that can be rendered, and a multiplier to turn 1 key press into many.


As a note, think it would be neat in the future to keep a map of what keys get pressed and have the frequency of key press result in the subsequent presses resulting in a LARGER character. As keys don't get pressed again their intensity can also decay. That's a task for another night... will it happen?.. depends on how bored I get.

Disclaimer: No guarantees to be bug free or best practice for javascript as I was just looking to get the change set in as quickly as possible.

Enjoy~ 